### PR TITLE
Fix ratelimit example

### DIFF
--- a/4-policy/rate-limiting/rate-limit-envoy-filter.yaml
+++ b/4-policy/rate-limiting/rate-limit-envoy-filter.yaml
@@ -27,7 +27,7 @@ spec:
              grpc_service:
                envoy_grpc:
                  cluster_name: rate_limit_service
-               timeout: 0.25s
+           timeout: 0.25s
     - applyTo: CLUSTER
       match:
         cluster:

--- a/4-policy/rate-limiting/rate-limit-envoy-filter.yaml
+++ b/4-policy/rate-limiting/rate-limit-envoy-filter.yaml
@@ -60,7 +60,7 @@ spec:
         context: GATEWAY
         routeConfiguration:
           vhost:
-            name: "*:80"
+            name: "*:80" # NOTE: this is an exact match not a glob match. It will not match 'example.com:80'
             route:
               action: ANY
       patch:


### PR DESCRIPTION
- The timeout configuration was not applying to the rate limit service requests as it was the wrong timeout set: 
  https://www.envoyproxy.io/docs/envoy/v1.15.0/api-v3/config/core/v3/grpc_service.proto#envoy-v3-api-field-config-core-v3-grpcservice-timeout
  The correct one is: https://www.envoyproxy.io/docs/envoy/v1.15.0/api- 
  v3/extensions/filters/http/ratelimit/v3/rate_limit.proto#envoy-v3-api-field-extensions-filters-http-ratelimit-v3-ratelimit-timeout
- added a note about how the vhost is matched because it is not straightforward on first look